### PR TITLE
add request.macOS; Change some logic to reflect it

### DIFF
--- a/detect/middleware.py
+++ b/detect/middleware.py
@@ -28,12 +28,14 @@ class UserAgentDetectionMiddleware(MiddlewareMixin):
         request.Windows = 'windows nt' in ua
         # Linux
         request.Linux = 'linux x86_64' in ua
-        # iMac、iPhone、iPad、iPod
-        request.iMac, request.iPhone, request.iPad, request.iPod = 'macintosh' in ua, 'iphone' in ua, 'ipad' in ua, 'ipod' in ua
+        # macOS
+        request.macOS = request.iMac = 'macintosh' in ua
+        # iPhone、iPad、iPod
+        request.iPhone, request.iPad, request.iPod = 'iphone' in ua, 'ipad' in ua, 'ipod' in ua
         # PC
-        request.PC = request.Windows or request.Linux or request.iMac
+        request.PC = request.Windows or request.Linux or request.iMac or request.macOS
         # iOS
-        request.iOS = request.iPhone or request.iPad or request.iMac or request.iPod
+        request.iOS = request.iPhone or request.iPad or request.iPod
         # Android
         request.Android = tfv(ua, pattern=r'android ([\d.]+)', s='android')
 


### PR DESCRIPTION
Thanks for this library!  It's really helpful on our project. :)

I noticed that there was no `request.macOS` like there was for Linux and Windows.  An iMac is a type of computer and not an OS.   I kept `request.iMac` around for backward compatibility and removed from the `request.iOS` element as it doesn't run iOS and was already in the PC element.

(fixed a typo in an earlier PR)